### PR TITLE
Add a benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,15 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+criterion = "0.3"
+kth = "0.1.0"
+order-stat = "0.1.3"
+pdqselect = "0.1.0"
+rand = "0.7.3"
+
+[[bench]]
+name = "compare"
+harness = false
+

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,0 +1,75 @@
+use criterion::AxisScale;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::PlotConfiguration;
+use criterion::{criterion_group, criterion_main};
+
+use floydrivest::nth_element;
+use kth::SliceExtKth;
+use order_stat::kth;
+use pdqselect::select;
+
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+fn floydrivest_benchmark(c: &mut Criterion) {
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    let mut group = c.benchmark_group("nth_element");
+    group.plot_config(plot_config);
+    for size in [1000, 10_000, 100_000, 1_000_000].iter() {
+        let k = (size/2) as usize;
+        //let k = 10;
+        group.bench_with_input(BenchmarkId::new("floydrivest", size), size, |b, &size| {
+            let mut v: Vec<u32> = (0..size).collect();
+            v.shuffle(&mut thread_rng());
+            b.iter_batched_ref(
+                || v.clone(),
+                |w: &mut std::vec::Vec<u32>| {
+                    nth_element(w, k, &mut Ord::cmp);
+                    assert_eq!(w[k], k as u32)
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+        group.bench_with_input(BenchmarkId::new("order_stat", size), size, |b, &size| {
+            let mut v: Vec<u32> = (0..size).collect();
+            v.shuffle(&mut thread_rng());
+            b.iter_batched_ref(
+                || v.clone(),
+                |w: &mut std::vec::Vec<u32>| {
+                    kth(w, k);
+                    assert_eq!(w[k], k as u32)
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+        group.bench_with_input(BenchmarkId::new("kth", size), size, |b, &size| {
+            let mut v: Vec<u32> = (0..size).collect();
+            v.shuffle(&mut thread_rng());
+            b.iter_batched_ref(
+                || v.clone(),
+                |w: &mut std::vec::Vec<u32>| {
+                    w.partition_by_kth(k);
+                    assert_eq!(w[k], k as u32)
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+        group.bench_with_input(BenchmarkId::new("pdqselect", size), size, |b, &size| {
+            let mut v: Vec<u32> = (0..size).collect();
+            v.shuffle(&mut thread_rng());
+            b.iter_batched_ref(
+                || v.clone(),
+                |w: &mut std::vec::Vec<u32>| {
+                    select(w, k);
+                    assert_eq!(w[k], k as u32)
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, floydrivest_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This commit adds a benchmark using [criterion framework](https://crates.io/crates/criterion). To run the benchmark:

    cargo bench

The results in html form are in `target/criterion/report` directory.

This benchmarks this library against crates [order-stat](https://crates.io/crates/order-stat), [kth](https://crates.io/crates/kth) and [pdqselect](https://crates.io/crates/pdqselect).

Currently, it benchmarks finding median of a randomly shuffled `Vec<u32>` for sizes in the range 1k-1M.

The result is:
![lines](https://user-images.githubusercontent.com/1054514/89737223-b0c2c180-da6f-11ea-8791-c51f9adf7206.png)
